### PR TITLE
F Gjør det mulig å endre dager og oppdatere beregning på meldekort

### DIFF
--- a/src/containers/meldekort-side/MeldekortBeregningsVisning.tsx
+++ b/src/containers/meldekort-side/MeldekortBeregningsVisning.tsx
@@ -1,7 +1,11 @@
 import { CheckmarkCircleFillIcon, ExclamationmarkTriangleFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import { BodyShort, Table } from '@navikt/ds-react';
 
-export const MeldekortBeregningsvisning = () => {
+interface MeldekortBeregningsvisningProps {
+    antallDagerIkkeDeltatt: number;
+}
+
+export const MeldekortBeregningsvisning = ({ antallDagerIkkeDeltatt }: MeldekortBeregningsvisningProps) => {
     return (
         <Table style={{ tableLayout: 'fixed', width: '100%' }}>
             <Table.Row>
@@ -65,7 +69,7 @@ export const MeldekortBeregningsvisning = () => {
                 </Table.DataCell>
                 <Table.DataCell>
                     <BodyShort style={{ marginBottom: '0.5rem' }}>5</BodyShort>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>0</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDagerIkkeDeltatt.toString()}</BodyShort>
                     <BodyShort style={{ marginBottom: '0.5rem' }}>0</BodyShort>
                     <BodyShort style={{ marginBottom: '0.5rem' }}>6</BodyShort>
                     <BodyShort style={{ marginBottom: '0.5rem' }}>0</BodyShort>

--- a/src/containers/meldekort-side/MeldekortBeregningsVisning.tsx
+++ b/src/containers/meldekort-side/MeldekortBeregningsVisning.tsx
@@ -3,9 +3,27 @@ import { BodyShort, Table } from '@navikt/ds-react';
 
 interface MeldekortBeregningsvisningProps {
     antallDagerIkkeDeltatt: number;
+    antallDagerDeltatt: number;
+    antallDagerSyk: number;
+    antallDagerVelferd: number;
+    antallDagerSyktBarn: number;
+    antallDager100prosent: number;
+    antallDager75prosent: number;
+    sumAntallDager100prosent: number;
+    sumAntallDager75prosent: number;
 }
 
-export const MeldekortBeregningsvisning = ({ antallDagerIkkeDeltatt }: MeldekortBeregningsvisningProps) => {
+export const MeldekortBeregningsvisning = ({
+    antallDagerIkkeDeltatt,
+    antallDagerDeltatt,
+    antallDagerSyk,
+    antallDagerSyktBarn,
+    antallDagerVelferd,
+    antallDager100prosent,
+    antallDager75prosent,
+    sumAntallDager100prosent,
+    sumAntallDager75prosent,
+}: MeldekortBeregningsvisningProps) => {
     return (
         <Table style={{ tableLayout: 'fixed', width: '100%' }}>
             <Table.Row>
@@ -68,13 +86,13 @@ export const MeldekortBeregningsvisning = ({ antallDagerIkkeDeltatt }: Meldekort
                     <BodyShort style={{ marginBottom: '0.5rem' }}>Antall dager med 100% utbetaling</BodyShort>
                 </Table.DataCell>
                 <Table.DataCell>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>5</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDagerDeltatt.toString()}</BodyShort>
                     <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDagerIkkeDeltatt.toString()}</BodyShort>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>0</BodyShort>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>6</BodyShort>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>0</BodyShort>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>2</BodyShort>
-                    <BodyShort style={{ marginBottom: '0.5rem' }}>2</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDagerSyk.toString()}</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDagerSyktBarn.toString()}</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDagerVelferd.toString()}</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDager75prosent.toString()}</BodyShort>
+                    <BodyShort style={{ marginBottom: '0.5rem' }}>{antallDager100prosent.toString()}</BodyShort>
                 </Table.DataCell>
                 <Table.DataCell align="right">
                     <div>
@@ -83,8 +101,10 @@ export const MeldekortBeregningsvisning = ({ antallDagerIkkeDeltatt }: Meldekort
                         <BodyShort style={{ marginBottom: '0.5rem' }}>&nbsp;</BodyShort>
                         <BodyShort style={{ marginBottom: '0.5rem' }}>&nbsp;</BodyShort>
                         <BodyShort style={{ marginBottom: '0.5rem' }}>&nbsp;</BodyShort>
-                        <BodyShort style={{ marginBottom: '0.5rem' }}>405,-</BodyShort>
-                        <BodyShort style={{ marginBottom: '0.5rem' }}>2144,-</BodyShort>
+                        <BodyShort style={{ marginBottom: '0.5rem' }}>{sumAntallDager75prosent.toString()},-</BodyShort>
+                        <BodyShort style={{ marginBottom: '0.5rem' }}>
+                            {sumAntallDager100prosent.toString()},-
+                        </BodyShort>
                     </div>
                 </Table.DataCell>
             </Table.Row>
@@ -92,7 +112,7 @@ export const MeldekortBeregningsvisning = ({ antallDagerIkkeDeltatt }: Meldekort
                 <Table.HeaderCell>Beløp til utbetaling</Table.HeaderCell>
                 <Table.DataCell />
                 <Table.DataCell align="right">
-                    <BodyShort>2569,-</BodyShort>
+                    <BodyShort>{(sumAntallDager100prosent + sumAntallDager75prosent).toString()},-</BodyShort>
                 </Table.DataCell>
             </Table.Row>
         </Table>

--- a/src/containers/meldekort-side/MeldekortUke.tsx
+++ b/src/containers/meldekort-side/MeldekortUke.tsx
@@ -7,10 +7,11 @@ interface MeldekortUkeProps {
     ukesnummer: number;
     fom: number;
     tom: number;
-    handleOppdaterMeldekort: (index: number, status: MeldekortStatus) => void;
+    handleOppdaterMeldekort: (index: number, status: MeldekortStatus, ukeNr: number) => void;
+    ukeNr: number;
 }
 
-export const MeldekortUke = ({ ukesnummer, meldekortUke, handleOppdaterMeldekort }: MeldekortUkeProps) => {
+export const MeldekortUke = ({ ukesnummer, meldekortUke, handleOppdaterMeldekort, ukeNr }: MeldekortUkeProps) => {
     function velgIkon(deltattEllerFravær: MeldekortStatus) {
         switch (deltattEllerFravær) {
             case MeldekortStatus.DELTATT:
@@ -48,10 +49,11 @@ export const MeldekortUke = ({ ukesnummer, meldekortUke, handleOppdaterMeldekort
 
     function oppdaterMeldekort(index: number, status: string) {
         const meldekortStatus = velgStatus(status);
-        handleOppdaterMeldekort(index, meldekortStatus);
+        handleOppdaterMeldekort(index, meldekortStatus, ukeNr);
     }
 
     var ukedagListe = meldekortUke.map((ukedag, index) => {
+        console.log('meldekortUke', meldekortUke);
         return (
             <Table.Row key={index}>
                 <Table.DataCell>{velgIkon(ukedag.status)}</Table.DataCell>

--- a/src/containers/meldekort-side/MeldekortUke.tsx
+++ b/src/containers/meldekort-side/MeldekortUke.tsx
@@ -2,17 +2,15 @@ import { Select, Table } from '@navikt/ds-react';
 import { CheckmarkCircleFillIcon, ExclamationmarkTriangleFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import { MeldekortDag, MeldekortStatus } from '../../types/MeldekortTypes';
 
-import React, { useState } from 'react';
-
 interface MeldekortUkeProps {
     meldekortUke: MeldekortDag[];
     ukesnummer: number;
     fom: number;
     tom: number;
-    handleOppdaterMeldekort: (arg1: number, arg2: string) => void;
+    handleOppdaterMeldekort: (index: number, status: MeldekortStatus) => void;
 }
 
-export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke, handleOppdaterMeldekort }: MeldekortUkeProps) => {
+export const MeldekortUke = ({ ukesnummer, meldekortUke, handleOppdaterMeldekort }: MeldekortUkeProps) => {
     function velgIkon(deltattEllerFravær: MeldekortStatus) {
         switch (deltattEllerFravær) {
             case MeldekortStatus.DELTATT:
@@ -28,6 +26,31 @@ export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke, handleOppdate
                 return <ExclamationmarkTriangleFillIcon style={{ color: 'orange' }} />;
         }
     }
+
+    function velgStatus(status: string) {
+        switch (status) {
+            case 'Deltatt':
+                return MeldekortStatus.DELTATT;
+            case 'Ikke deltatt':
+                return MeldekortStatus.IKKE_DELTATT;
+            case 'Lønn for tid i arbeid':
+                return MeldekortStatus.LØNN_FOR_TID_I_ARBEID;
+            case 'Fravær syk':
+                return MeldekortStatus.FRAVÆR_SYK;
+            case 'Fravær sykt barn':
+                return MeldekortStatus.FRAVÆR_SYKT_BARN;
+            case 'Fravær velferd':
+                return MeldekortStatus.FRAVÆR_VELFERD;
+            default:
+                return MeldekortStatus.IKKE_DELTATT;
+        }
+    }
+
+    function oppdaterMeldekort(index: number, status: string) {
+        const meldekortStatus = velgStatus(status);
+        handleOppdaterMeldekort(index, meldekortStatus);
+    }
+
     var ukedagListe = meldekortUke.map((ukedag, index) => {
         return (
             <Table.Row key={index}>
@@ -41,7 +64,8 @@ export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke, handleOppdate
                         id="deltattEllerFravær"
                         size="small"
                         hideLabel
-                        onChange={(e) => handleOppdaterMeldekort(index, e.target.value)}
+                        defaultValue={ukedag.status}
+                        onChange={(e) => oppdaterMeldekort(index, e.target.value)}
                     >
                         <option value={MeldekortStatus.DELTATT}>Deltatt i tiltaket</option>
                         <option value={MeldekortStatus.IKKE_DELTATT}>Ikke deltatt i tiltaket</option>

--- a/src/containers/meldekort-side/MeldekortUke.tsx
+++ b/src/containers/meldekort-side/MeldekortUke.tsx
@@ -1,32 +1,19 @@
 import { Select, Table } from '@navikt/ds-react';
-import {
-    CheckmarkCircleFillIcon,
-    ExclamationmarkTriangleFillIcon,
-    XMarkOctagonFillIcon,
-} from '@navikt/aksel-icons';
+import { CheckmarkCircleFillIcon, ExclamationmarkTriangleFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import { MeldekortDag, MeldekortStatus } from '../../types/MeldekortTypes';
 
 import React, { useState } from 'react';
 
 interface MeldekortUkeProps {
-    meldekortUke?: MeldekortDag[];
+    meldekortUke: MeldekortDag[];
     ukesnummer: number;
     fom: number;
     tom: number;
+    handleOppdaterMeldekort: (arg1: number, arg2: string) => void;
 }
 
-export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke }: MeldekortUkeProps) => {
-    const meldekortUker: MeldekortDag[] = [
-        { dag: 'Mandag', dato: new Date('2023-11-13'), status: MeldekortStatus.DELTATT },
-        { dag: 'Tirsdag', dato: new Date('2023-11-14'), status: MeldekortStatus.IKKE_DELTATT },
-        { dag: 'Onsdag', dato: new Date('2023-11-15'), status: MeldekortStatus.FRAVÆR_SYK },
-        { dag: 'Torsdag', dato: new Date('2023-11-16'), status: MeldekortStatus.FRAVÆR_SYKT_BARN },
-        { dag: 'Fredag', dato: new Date('2023-11-17'), status: MeldekortStatus.DELTATT },
-        { dag: 'Lørdag', dato: new Date('2023-11-18'), status: MeldekortStatus.IKKE_DELTATT },
-        { dag: 'Søndag', dato: new Date('2023-11-19'), status: MeldekortStatus.IKKE_DELTATT },
-    ];
-
-    function velgIkon(deltattEllerFravær: String) {
+export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke, handleOppdaterMeldekort }: MeldekortUkeProps) => {
+    function velgIkon(deltattEllerFravær: MeldekortStatus) {
         switch (deltattEllerFravær) {
             case MeldekortStatus.DELTATT:
                 return <CheckmarkCircleFillIcon style={{ color: 'green' }} />;
@@ -41,7 +28,7 @@ export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke }: MeldekortUk
                 return <ExclamationmarkTriangleFillIcon style={{ color: 'orange' }} />;
         }
     }
-    var ukedagListe = meldekortUker.map((ukedag, index) => {
+    var ukedagListe = meldekortUke.map((ukedag, index) => {
         return (
             <Table.Row key={index}>
                 <Table.DataCell>{velgIkon(ukedag.status)}</Table.DataCell>
@@ -54,12 +41,14 @@ export const MeldekortUke = ({ ukesnummer, fom, tom, meldekortUke }: MeldekortUk
                         id="deltattEllerFravær"
                         size="small"
                         hideLabel
+                        onChange={(e) => handleOppdaterMeldekort(index, e.target.value)}
                     >
-                        <option value="Deltatt">Deltatt i tiltaket</option>
-                        <option value="Ikke_deltatt">Ikke deltatt i tiltaket</option>
-                        <option value="Lønn">Lønn for tid i tiltaket</option>
-                        <option value="sykefravær">Fravær syk</option>
-                        <option value="velferdPermisjon">Fravær velferd</option>
+                        <option value={MeldekortStatus.DELTATT}>Deltatt i tiltaket</option>
+                        <option value={MeldekortStatus.IKKE_DELTATT}>Ikke deltatt i tiltaket</option>
+                        <option value={MeldekortStatus.LØNN_FOR_TID_I_ARBEID}>Lønn for tid i arbeid</option>
+                        <option value={MeldekortStatus.FRAVÆR_SYK}>Fravær syk</option>
+                        <option value={MeldekortStatus.FRAVÆR_SYKT_BARN}>Fravær sykt barn</option>
+                        <option value={MeldekortStatus.FRAVÆR_VELFERD}>Fravær velferd</option>
                     </Select>
                 </Table.DataCell>
             </Table.Row>

--- a/src/containers/søknad-tabs/MeldekortSide.tsx
+++ b/src/containers/søknad-tabs/MeldekortSide.tsx
@@ -3,7 +3,7 @@ import { MeldekortUke } from '../meldekort-side/MeldekortUke';
 import { MeldekortBeregningsvisning } from '../meldekort-side/MeldekortBeregningsVisning';
 import { PencilWritingIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MeldekortDag, MeldekortStatus } from '../../types/MeldekortTypes';
 
 interface MeldekortSideProps extends React.PropsWithChildren {
@@ -30,35 +30,36 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
         { dag: 'Lørdag', dato: new Date('2023-11-25'), status: MeldekortStatus.IKKE_DELTATT },
         { dag: 'Søndag', dato: new Date('2023-11-26'), status: MeldekortStatus.IKKE_DELTATT },
     ];
+
     const [oppdatertMeldekort1, setOppdaterMeldekort1] = useState([...meldekortUke1]);
     const [oppdatertMeldekort2, setOppdaterMeldekort2] = useState([...meldekortUke2]);
+    const [antallDagerIkkeDeltatt, settAntallDagerIkkeDeltatt] = useState<number>(0);
 
-    const handleOppdaterMeldekort1 = (index: number, nyStatus: any) => {
-        console.log('nyStatus', nyStatus);
-        console.log('index', index);
-        const oppdatertMeldekortUkerKopi = [...meldekortUke1];
+    useEffect(() => {
+        beregnAntallDagerIkkeDeltatt(oppdatertMeldekort1, oppdatertMeldekort2);
+    });
+
+    const handleOppdaterMeldekort1 = (index: number, nyStatus: MeldekortStatus) => {
+        const oppdatertMeldekortUkerKopi = [...oppdatertMeldekort1];
         oppdatertMeldekortUkerKopi[index].status = nyStatus;
         setOppdaterMeldekort1(oppdatertMeldekortUkerKopi);
+        beregnAntallDagerIkkeDeltatt(oppdatertMeldekort1, oppdatertMeldekort2);
     };
-    const handleOppdaterMeldekort2 = (index: number, nyStatus: any) => {
-        const oppdatertMeldekortUkerKopi = [...meldekortUke2];
+    const handleOppdaterMeldekort2 = (index: number, nyStatus: MeldekortStatus) => {
+        const oppdatertMeldekortUkerKopi = [...oppdatertMeldekort2];
         oppdatertMeldekortUkerKopi[index].status = nyStatus;
         setOppdaterMeldekort2(oppdatertMeldekortUkerKopi);
+        beregnAntallDagerIkkeDeltatt(oppdatertMeldekort1, oppdatertMeldekort2);
     };
-    const beregnAntallDagerIkkeDeltatt = (meldekortUke1, meldekortUke2) => {
-        const antallUke1 = meldekortUke1.reduce((countMap: { [x: string]: any }, meldekort: { status: any }) => {
-            const status = meldekort.status;
-            countMap[status] = (countMap[status] || 0) + 1;
-            return countMap;
-        });
+    const beregnAntallDagerIkkeDeltatt = (meldekortUke1: MeldekortDag[], meldekortUke2: MeldekortDag[]) => {
+        const antallDager1 = meldekortUke1.filter(
+            (dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT
+        ).length;
+        const antallDager2 = meldekortUke2.filter(
+            (dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT
+        ).length;
 
-        const antallUke2 = meldekortUke2.reduce((countMap: { [x: string]: any }, meldekort: { status: any }) => {
-            const status = meldekort.status;
-            countMap[status] = (countMap[status] || 0) + 1;
-            return countMap;
-        });
-        console.log('antalluke1', antallUke1);
-        return antallUke1 + antallUke2;
+        settAntallDagerIkkeDeltatt(antallDager1 + antallDager2);
     };
 
     const godkjennMeldekort = () => {
@@ -75,7 +76,7 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
                         fom={1}
                         tom={7}
                         handleOppdaterMeldekort={handleOppdaterMeldekort1}
-                    ></MeldekortUke>
+                    />
                 </div>
                 <div className={styles.uke2}>
                     <MeldekortUke
@@ -84,7 +85,7 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
                         fom={8}
                         tom={14}
                         handleOppdaterMeldekort={handleOppdaterMeldekort2}
-                    ></MeldekortUke>
+                    />
                 </div>
             </div>
 

--- a/src/containers/søknad-tabs/MeldekortSide.tsx
+++ b/src/containers/søknad-tabs/MeldekortSide.tsx
@@ -33,7 +33,9 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
     const [antallDagerIkkeDeltatt, settAntallDagerIkkeDeltatt] = useState<number>(0);
 
     useEffect(() => {
-        beregnAntallDagerIkkeDeltatt(meldekortUker);
+        settAntallDagerIkkeDeltatt(
+            oppdatertMeldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT).length
+        );
     });
 
     const handleOppdaterMeldekort = (index: number, nyStatus: MeldekortStatus, ukeNr: number) => {
@@ -44,15 +46,6 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
             oppdatertMeldekortUkerKopi[index].status = nyStatus;
         }
         setOppdaterMeldekortUker(oppdatertMeldekortUkerKopi);
-        beregnAntallDagerIkkeDeltatt(meldekortUker);
-    };
-
-    const beregnAntallDagerIkkeDeltatt = (meldekortUker: MeldekortDag[]) => {
-        const antallDager1 = meldekortUker.filter(
-            (dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT
-        ).length;
-
-        settAntallDagerIkkeDeltatt(antallDager1);
     };
 
     const godkjennMeldekort = () => {

--- a/src/containers/søknad-tabs/MeldekortSide.tsx
+++ b/src/containers/søknad-tabs/MeldekortSide.tsx
@@ -12,7 +12,7 @@ interface MeldekortSideProps extends React.PropsWithChildren {
 
 export const MeldekortSide = ({}: MeldekortSideProps) => {
     const [disableUkeVisning, setDisableUkeVisning] = useState<boolean>(false);
-    const meldekortUke1: MeldekortDag[] = [
+    const meldekortUker: MeldekortDag[] = [
         { dag: 'Mandag', dato: new Date('2023-11-13'), status: MeldekortStatus.IKKE_DELTATT },
         { dag: 'Tirsdag', dato: new Date('2023-11-14'), status: MeldekortStatus.IKKE_DELTATT },
         { dag: 'Onsdag', dato: new Date('2023-11-15'), status: MeldekortStatus.FRAVÆR_SYKT_BARN },
@@ -20,8 +20,6 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
         { dag: 'Fredag', dato: new Date('2023-11-17'), status: MeldekortStatus.DELTATT },
         { dag: 'Lørdag', dato: new Date('2023-11-18'), status: MeldekortStatus.IKKE_DELTATT },
         { dag: 'Søndag', dato: new Date('2023-11-19'), status: MeldekortStatus.IKKE_DELTATT },
-    ];
-    const meldekortUke2: MeldekortDag[] = [
         { dag: 'Mandag', dato: new Date('2023-11-20'), status: MeldekortStatus.DELTATT },
         { dag: 'Tirsdag', dato: new Date('2023-11-21'), status: MeldekortStatus.LØNN_FOR_TID_I_ARBEID },
         { dag: 'Onsdag', dato: new Date('2023-11-22'), status: MeldekortStatus.FRAVÆR_SYK },
@@ -31,35 +29,30 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
         { dag: 'Søndag', dato: new Date('2023-11-26'), status: MeldekortStatus.IKKE_DELTATT },
     ];
 
-    const [oppdatertMeldekort1, setOppdaterMeldekort1] = useState([...meldekortUke1]);
-    const [oppdatertMeldekort2, setOppdaterMeldekort2] = useState([...meldekortUke2]);
+    const [oppdatertMeldekortUker, setOppdaterMeldekortUker] = useState([...meldekortUker]);
     const [antallDagerIkkeDeltatt, settAntallDagerIkkeDeltatt] = useState<number>(0);
 
     useEffect(() => {
-        beregnAntallDagerIkkeDeltatt(oppdatertMeldekort1, oppdatertMeldekort2);
+        beregnAntallDagerIkkeDeltatt(meldekortUker);
     });
 
-    const handleOppdaterMeldekort1 = (index: number, nyStatus: MeldekortStatus) => {
-        const oppdatertMeldekortUkerKopi = [...oppdatertMeldekort1];
-        oppdatertMeldekortUkerKopi[index].status = nyStatus;
-        setOppdaterMeldekort1(oppdatertMeldekortUkerKopi);
-        beregnAntallDagerIkkeDeltatt(oppdatertMeldekort1, oppdatertMeldekort2);
+    const handleOppdaterMeldekort = (index: number, nyStatus: MeldekortStatus, ukeNr: number) => {
+        const oppdatertMeldekortUkerKopi = [...oppdatertMeldekortUker];
+        if (ukeNr == 2) {
+            oppdatertMeldekortUkerKopi[index + 7].status = nyStatus;
+        } else {
+            oppdatertMeldekortUkerKopi[index].status = nyStatus;
+        }
+        setOppdaterMeldekortUker(oppdatertMeldekortUkerKopi);
+        beregnAntallDagerIkkeDeltatt(meldekortUker);
     };
-    const handleOppdaterMeldekort2 = (index: number, nyStatus: MeldekortStatus) => {
-        const oppdatertMeldekortUkerKopi = [...oppdatertMeldekort2];
-        oppdatertMeldekortUkerKopi[index].status = nyStatus;
-        setOppdaterMeldekort2(oppdatertMeldekortUkerKopi);
-        beregnAntallDagerIkkeDeltatt(oppdatertMeldekort1, oppdatertMeldekort2);
-    };
-    const beregnAntallDagerIkkeDeltatt = (meldekortUke1: MeldekortDag[], meldekortUke2: MeldekortDag[]) => {
-        const antallDager1 = meldekortUke1.filter(
-            (dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT
-        ).length;
-        const antallDager2 = meldekortUke2.filter(
+
+    const beregnAntallDagerIkkeDeltatt = (meldekortUker: MeldekortDag[]) => {
+        const antallDager1 = meldekortUker.filter(
             (dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT
         ).length;
 
-        settAntallDagerIkkeDeltatt(antallDager1 + antallDager2);
+        settAntallDagerIkkeDeltatt(antallDager1);
     };
 
     const godkjennMeldekort = () => {
@@ -71,20 +64,22 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
             <div className={disableUkeVisning ? styles.disableUkevisning : styles.ukevisning}>
                 <div className={styles.uke1}>
                     <MeldekortUke
-                        meldekortUke={oppdatertMeldekort1}
+                        meldekortUke={oppdatertMeldekortUker.slice(0, 7)}
                         ukesnummer={1}
                         fom={1}
                         tom={7}
-                        handleOppdaterMeldekort={handleOppdaterMeldekort1}
+                        ukeNr={1}
+                        handleOppdaterMeldekort={handleOppdaterMeldekort}
                     />
                 </div>
                 <div className={styles.uke2}>
                     <MeldekortUke
-                        meldekortUke={oppdatertMeldekort2}
+                        meldekortUke={oppdatertMeldekortUker.slice(7, 14)}
                         ukesnummer={2}
                         fom={8}
                         tom={14}
-                        handleOppdaterMeldekort={handleOppdaterMeldekort2}
+                        ukeNr={2}
+                        handleOppdaterMeldekort={handleOppdaterMeldekort}
                     />
                 </div>
             </div>

--- a/src/containers/søknad-tabs/MeldekortSide.tsx
+++ b/src/containers/søknad-tabs/MeldekortSide.tsx
@@ -1,39 +1,105 @@
 import styles from './meldekort.module.css';
 import { MeldekortUke } from '../meldekort-side/MeldekortUke';
 import { MeldekortBeregningsvisning } from '../meldekort-side/MeldekortBeregningsVisning';
-import {PencilWritingIcon} from "@navikt/aksel-icons";
-import {Button} from "@navikt/ds-react";
-import React, {useState} from "react";
+import { PencilWritingIcon } from '@navikt/aksel-icons';
+import { Button } from '@navikt/ds-react';
+import React, { useState } from 'react';
+import { MeldekortDag, MeldekortStatus } from '../../types/MeldekortTypes';
 
 interface MeldekortSideProps extends React.PropsWithChildren {
     title?: string;
 }
 
 export const MeldekortSide = ({}: MeldekortSideProps) => {
-    const [ disableUkeVisning, setDisableUkeVisning] = useState<boolean>(false);
+    const [disableUkeVisning, setDisableUkeVisning] = useState<boolean>(false);
+    const meldekortUke1: MeldekortDag[] = [
+        { dag: 'Mandag', dato: new Date('2023-11-13'), status: MeldekortStatus.IKKE_DELTATT },
+        { dag: 'Tirsdag', dato: new Date('2023-11-14'), status: MeldekortStatus.IKKE_DELTATT },
+        { dag: 'Onsdag', dato: new Date('2023-11-15'), status: MeldekortStatus.FRAVÆR_SYKT_BARN },
+        { dag: 'Torsdag', dato: new Date('2023-11-16'), status: MeldekortStatus.FRAVÆR_SYKT_BARN },
+        { dag: 'Fredag', dato: new Date('2023-11-17'), status: MeldekortStatus.DELTATT },
+        { dag: 'Lørdag', dato: new Date('2023-11-18'), status: MeldekortStatus.IKKE_DELTATT },
+        { dag: 'Søndag', dato: new Date('2023-11-19'), status: MeldekortStatus.IKKE_DELTATT },
+    ];
+    const meldekortUke2: MeldekortDag[] = [
+        { dag: 'Mandag', dato: new Date('2023-11-20'), status: MeldekortStatus.DELTATT },
+        { dag: 'Tirsdag', dato: new Date('2023-11-21'), status: MeldekortStatus.LØNN_FOR_TID_I_ARBEID },
+        { dag: 'Onsdag', dato: new Date('2023-11-22'), status: MeldekortStatus.FRAVÆR_SYK },
+        { dag: 'Torsdag', dato: new Date('2023-11-23'), status: MeldekortStatus.DELTATT },
+        { dag: 'Fredag', dato: new Date('2023-11-24'), status: MeldekortStatus.DELTATT },
+        { dag: 'Lørdag', dato: new Date('2023-11-25'), status: MeldekortStatus.IKKE_DELTATT },
+        { dag: 'Søndag', dato: new Date('2023-11-26'), status: MeldekortStatus.IKKE_DELTATT },
+    ];
+    const [oppdatertMeldekort1, setOppdaterMeldekort1] = useState([...meldekortUke1]);
+    const [oppdatertMeldekort2, setOppdaterMeldekort2] = useState([...meldekortUke2]);
+
+    const handleOppdaterMeldekort1 = (index: number, nyStatus: any) => {
+        console.log('nyStatus', nyStatus);
+        console.log('index', index);
+        const oppdatertMeldekortUkerKopi = [...meldekortUke1];
+        oppdatertMeldekortUkerKopi[index].status = nyStatus;
+        setOppdaterMeldekort1(oppdatertMeldekortUkerKopi);
+    };
+    const handleOppdaterMeldekort2 = (index: number, nyStatus: any) => {
+        const oppdatertMeldekortUkerKopi = [...meldekortUke2];
+        oppdatertMeldekortUkerKopi[index].status = nyStatus;
+        setOppdaterMeldekort2(oppdatertMeldekortUkerKopi);
+    };
+    const beregnAntallDagerIkkeDeltatt = (meldekortUke1, meldekortUke2) => {
+        const antallUke1 = meldekortUke1.reduce((countMap: { [x: string]: any }, meldekort: { status: any }) => {
+            const status = meldekort.status;
+            countMap[status] = (countMap[status] || 0) + 1;
+            return countMap;
+        });
+
+        const antallUke2 = meldekortUke2.reduce((countMap: { [x: string]: any }, meldekort: { status: any }) => {
+            const status = meldekort.status;
+            countMap[status] = (countMap[status] || 0) + 1;
+            return countMap;
+        });
+        console.log('antalluke1', antallUke1);
+        return antallUke1 + antallUke2;
+    };
 
     const godkjennMeldekort = () => {
         setDisableUkeVisning(true);
-    }
+    };
 
     return (
         <>
-            <div className={ disableUkeVisning ? styles.disableUkevisning : styles.ukevisning }>
+            <div className={disableUkeVisning ? styles.disableUkevisning : styles.ukevisning}>
                 <div className={styles.uke1}>
-                    <MeldekortUke ukesnummer={1} fom={1} tom={7}></MeldekortUke>
+                    <MeldekortUke
+                        meldekortUke={oppdatertMeldekort1}
+                        ukesnummer={1}
+                        fom={1}
+                        tom={7}
+                        handleOppdaterMeldekort={handleOppdaterMeldekort1}
+                    ></MeldekortUke>
                 </div>
                 <div className={styles.uke2}>
-                    <MeldekortUke ukesnummer={2} fom={8} tom={14}></MeldekortUke>
+                    <MeldekortUke
+                        meldekortUke={oppdatertMeldekort2}
+                        ukesnummer={2}
+                        fom={8}
+                        tom={14}
+                        handleOppdaterMeldekort={handleOppdaterMeldekort2}
+                    ></MeldekortUke>
                 </div>
             </div>
 
-            <MeldekortBeregningsvisning />
+            <MeldekortBeregningsvisning antallDagerIkkeDeltatt={antallDagerIkkeDeltatt} />
 
-            <div style={{ marginTop: '2rem', justifyItems: 'center', alignItems: 'center'}}>
-                <Button icon={<PencilWritingIcon />} variant="tertiary" size="small" onClick={()=> setDisableUkeVisning(false)}>
+            <div style={{ marginTop: '2rem', justifyItems: 'center', alignItems: 'center' }}>
+                <Button
+                    icon={<PencilWritingIcon />}
+                    variant="tertiary"
+                    size="small"
+                    onClick={() => setDisableUkeVisning(false)}
+                >
                     Endre meldekortperiode
                 </Button>
-                <Button size="small" style={{ marginLeft: '2rem'}} onClick={godkjennMeldekort}>
+                <Button size="small" style={{ marginLeft: '2rem' }} onClick={godkjennMeldekort}>
                     Godkjenn meldekortperiode
                 </Button>
             </div>

--- a/src/containers/søknad-tabs/MeldekortSide.tsx
+++ b/src/containers/søknad-tabs/MeldekortSide.tsx
@@ -30,12 +30,31 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
     ];
 
     const [oppdatertMeldekortUker, setOppdaterMeldekortUker] = useState([...meldekortUker]);
-    const [antallDagerIkkeDeltatt, settAntallDagerIkkeDeltatt] = useState<number>(0);
+    const [antallDagerIkkeDeltatt, setAntallDagerIkkeDeltatt] = useState<number>(
+        meldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT).length
+    );
+    const [antallDagerDeltatt, setAntallDagerDeltatt] = useState<number>(
+        meldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.DELTATT).length
+    );
+    const [antallDagerSyk, setAntallDagerSyk] = useState<number>(
+        meldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.FRAVÆR_SYK).length
+    );
+    const [antallDagerSyktBarn, setAntallDagerSyktBarn] = useState<number>(
+        meldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.FRAVÆR_SYKT_BARN).length
+    );
+    const [antallDagerVelferd, setAntallDagerVelferd] = useState<number>(
+        meldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.FRAVÆR_VELFERD).length
+    );
+    const [antallDager100prosent, setAntallDager100prosent] = useState<number>(0);
+    const [antallDager75prosent, setAntallDager75prosent] = useState<number>(0);
+    const [sumAntallDager100prosent, setSumAntallDager100prosent] = useState<number>(0);
+    const [sumAntallDager75prosent, setSumAntallDager75prosent] = useState<number>(0);
+    const egenMeldingsdager = 3;
+    const dagsats = 268;
 
     useEffect(() => {
-        settAntallDagerIkkeDeltatt(
-            oppdatertMeldekortUker.filter((dag: MeldekortDag) => dag.status === MeldekortStatus.IKKE_DELTATT).length
-        );
+        finnAntallDagerMedRiktigUtbetalingsprosent();
+        beregnRiktigSum();
     });
 
     const handleOppdaterMeldekort = (index: number, nyStatus: MeldekortStatus, ukeNr: number) => {
@@ -46,6 +65,33 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
             oppdatertMeldekortUkerKopi[index].status = nyStatus;
         }
         setOppdaterMeldekortUker(oppdatertMeldekortUkerKopi);
+        setAntallDagerIkkeDeltatt(finnAntallDager(MeldekortStatus.IKKE_DELTATT));
+        setAntallDagerDeltatt(finnAntallDager(MeldekortStatus.DELTATT));
+        setAntallDagerSyk(finnAntallDager(MeldekortStatus.FRAVÆR_SYK));
+        setAntallDagerSyktBarn(finnAntallDager(MeldekortStatus.FRAVÆR_SYKT_BARN));
+        setAntallDagerVelferd(finnAntallDager(MeldekortStatus.FRAVÆR_VELFERD));
+        finnAntallDagerMedRiktigUtbetalingsprosent();
+        beregnRiktigSum();
+    };
+
+    const finnAntallDager = (meldekortStatus: MeldekortStatus) => {
+        return oppdatertMeldekortUker.filter((dag: MeldekortDag) => dag.status === meldekortStatus).length;
+    };
+
+    const finnAntallDagerMedRiktigUtbetalingsprosent = () => {
+        const sykedager = antallDagerSyk + antallDagerSyktBarn;
+        if (sykedager > egenMeldingsdager) {
+            setAntallDager100prosent(antallDagerDeltatt + egenMeldingsdager + antallDagerVelferd);
+            setAntallDager75prosent(sykedager - egenMeldingsdager);
+        } else {
+            setAntallDager75prosent(0);
+            setAntallDager100prosent(sykedager + antallDagerDeltatt + antallDagerVelferd);
+        }
+    };
+
+    const beregnRiktigSum = () => {
+        setSumAntallDager100prosent(antallDager100prosent * dagsats);
+        setSumAntallDager75prosent(antallDager75prosent * dagsats * 0.75);
     };
 
     const godkjennMeldekort = () => {
@@ -77,7 +123,17 @@ export const MeldekortSide = ({}: MeldekortSideProps) => {
                 </div>
             </div>
 
-            <MeldekortBeregningsvisning antallDagerIkkeDeltatt={antallDagerIkkeDeltatt} />
+            <MeldekortBeregningsvisning
+                antallDagerIkkeDeltatt={antallDagerIkkeDeltatt}
+                antallDagerDeltatt={antallDagerDeltatt}
+                antallDagerSyk={antallDagerSyk}
+                antallDagerSyktBarn={antallDagerSyktBarn}
+                antallDagerVelferd={antallDagerVelferd}
+                antallDager100prosent={antallDager100prosent}
+                antallDager75prosent={antallDager75prosent}
+                sumAntallDager100prosent={sumAntallDager100prosent}
+                sumAntallDager75prosent={sumAntallDager75prosent}
+            />
 
             <div style={{ marginTop: '2rem', justifyItems: 'center', alignItems: 'center' }}>
                 <Button


### PR DESCRIPTION
Når en saksbehandler er inne og oppdaterer meldekortet blir det i dag endret i GUI. 
Det gjøres også en enkel beregning i frontend for å vise riktig sum basert på hvilke dager som er endret

Når vi får sett på backend og databasestrukturen ønsker vi at en del av denne funksjonaliteten skal ligge i backenden til meldekortet. Men for demo i morgen og for å lære oss hvordan beregning fungerer sammen med fag er det løst i frontend først. 

Dette trellokortet hører til: https://trello.com/c/HkFw9Q3J