### PR TITLE
565 hent behandlinger for ident

### DIFF
--- a/src/containers/header/Header.tsx
+++ b/src/containers/header/Header.tsx
@@ -1,10 +1,10 @@
 import React, {FormEvent, useContext} from 'react';
 import { InternalHeader } from '@navikt/ds-react';
 import { Search } from '@navikt/ds-react';
-import { Saksbehandler } from '../../types/Saksbehandler';
 import styles from './Header.module.css';
 import Loaders from '../../components/loaders/Loaders';
 import {SaksbehandlerContext} from "../../pages/_app";
+import {useRouter} from "next/router";
 
 interface HeaderProps {
     onSearch: (searchQuery: string) => void;
@@ -12,6 +12,7 @@ interface HeaderProps {
 }
 
 const Header = ({ onSearch, isSearchLoading }: HeaderProps) => {
+    const router = useRouter();
     const [search, setSearch] = React.useState('');
     const { innloggetSaksbehandler } = useContext(SaksbehandlerContext);
 
@@ -33,7 +34,14 @@ const Header = ({ onSearch, isSearchLoading }: HeaderProps) => {
                             data-testid="nav-search-input"
                             label={''}
                             placeholder="Søk på fødselsnummer"
-                            onChange={(value) => setSearch(value.trim())}
+                            onChange={(value) => {
+                                const searchTerm = value.trim();
+                                setSearch(searchTerm)
+                                if (!searchTerm) {
+                                    onSearch(value.trim());
+                                    router.back();
+                                }
+                            }}
                             value={search}
                             autoComplete="off"
                         >

--- a/src/containers/header/Header.tsx
+++ b/src/containers/header/Header.tsx
@@ -38,8 +38,7 @@ const Header = ({ onSearch, isSearchLoading }: HeaderProps) => {
                                 const searchTerm = value.trim();
                                 setSearch(searchTerm)
                                 if (!searchTerm) {
-                                    onSearch(value.trim());
-                                    router.back();
+                                    router.push('/');
                                 }
                             }}
                             value={search}

--- a/src/core/useSokOppPerson.ts
+++ b/src/core/useSokOppPerson.ts
@@ -1,12 +1,8 @@
-import { useEffect, useState } from 'react';
-import useSWR from 'swr';
-import { Behandling } from '../types/Behandling';
-import Søker, {SøkerIdent, SøkerResponse} from '../types/Søker';
-import { fetcher, FetcherError, fetchSøker } from '../utils/http';
+import { FetcherError, fetchSøker } from '../utils/http';
 import toast from 'react-hot-toast';
-import { Saksbehandler } from '../types/Saksbehandler';
 import useSWRMutation from 'swr/mutation';
 import { useRouter } from 'next/router';
+import {SøkerIdent, SøkerResponse} from "../types/Søker";
 
 function useSokOppPerson(navigateToSoker: boolean = true) {
     const router = useRouter();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,23 +6,13 @@ import useSWR, {useSWRConfig} from 'swr';
 import { fetcher, FetcherError } from '../utils/http';
 import {Button, Link, Table} from '@navikt/ds-react';
 import {SaksbehandlerContext} from "./_app";
-
-interface Behandling {
-    id: string;
-    ident: string;
-    typeBehandling: string;
-    fom: string;
-    tom: string;
-    status: string;
-    saksbehandler?: string;
-    beslutter?: string;
-}
+import {BehandlingForBenk} from "../types/Behandling";
 
 const HomePage: NextPage = () => {
-    const [behandlinger, setBehandlinger] = useState<Behandling[]>([]);
+    const [behandlinger, setBehandlinger] = useState<BehandlingForBenk[]>([]);
     const { innloggetSaksbehandler } = useContext(SaksbehandlerContext);
     const mutator = useSWRConfig().mutate;
-    const { data, isLoading } = useSWR<Behandling[]>(`/api/behandlinger`, fetcher, {
+    const { data, isLoading } = useSWR<BehandlingForBenk[]>(`/api/behandlinger`, fetcher, {
         shouldRetryOnError: false,
         revalidateOnFocus: false,
         revalidateOnReconnect: false,

--- a/src/pages/soker/[...all].tsx
+++ b/src/pages/soker/[...all].tsx
@@ -17,14 +17,12 @@ const SøkerPage: NextPage = () => {
 
     const { innloggetSaksbehandler } = useContext(SaksbehandlerContext);
 
-    const [behandlingerForIdent, setBehandlinger] = useState<BehandlingForBenk[]>([]);
-    const { isLoading } = useSWR<BehandlingForBenk[]>(`/api/behandlinger/hentForIdent/${søkerId}`, fetcher, {
+    const { data, isLoading } = useSWR<BehandlingForBenk[]>(`/api/behandlinger/hentForIdent/${søkerId}`, fetcher, {
         shouldRetryOnError: false,
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
         onSuccess: (data) => {
             console.log(data);
-            setBehandlinger(data);
         },
         onError: (error: FetcherError) => toast.error(`[${error.status}]: ${error.info}`),
     });
@@ -32,6 +30,8 @@ const SøkerPage: NextPage = () => {
     if (isLoading) {
         return <Loaders.Page />;
     }
+
+    const behandlingerForIdent = data;
 
     const behandlingLinkAktivert = (saksbehandlerForBehandling?: string, beslutterForBehandling?: string) => {
         return (innloggetSaksbehandler?.navIdent == saksbehandlerForBehandling || innloggetSaksbehandler?.navIdent == beslutterForBehandling) ||

--- a/src/types/Behandling.ts
+++ b/src/types/Behandling.ts
@@ -28,6 +28,17 @@ export interface Behandling {
     status: string;
 }
 
+export interface BehandlingForBenk {
+    id: string;
+    ident: string;
+    typeBehandling: string;
+    fom: string;
+    tom: string;
+    status: string;
+    saksbehandler?: string;
+    beslutter?: string;
+}
+
 export interface Personopplysninger {
     ident: string;
     fornavn: string;


### PR DESCRIPTION
## Beskrivelse
Viser behandlinger for en person i en benk lik den som vises for alle behandlinger, men uten ident-kolonne.

## Kommentarer
Enkelte ting burde vært dratt ut i komponenter, men det gjelder også den andre benken, så dette kan tas i en egen refaktorbranch, gjerne sammen med annen ryddig i mappestruktur.

## Visuelle endringer:
<img width="1227" alt="image" src="https://github.com/navikt/tiltakspenger-saksbehandler/assets/122793479/4c6a94d8-0fbe-4a17-906b-cd00a996c9b8">
