### PR TITLE
La meldekort som outbound appen til saksbehandler flaten

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -22,6 +22,11 @@ spec:
     outbound:
       rules:
         - application: tiltakspenger-vedtak
+          namespace: tpts
+          cluster: {{ cluster }}
+        - application: tiltakspenger-meldekort-api
+          namespace: tpts
+          cluster: {{ cluster }}
   azure:
     sidecar:
       enabled: true

--- a/.nais/vars/dev.yaml
+++ b/.nais/vars/dev.yaml
@@ -4,9 +4,12 @@ replyURLs:
   - https://tiltakspenger-saksbehandler.intern.dev.nav.no/oauth2/callback
 tenant: trygdeetaten.no
 ROLE_SAKSBEHANDLER: 1b3a2c4d-d620-4fcf-a29b-a6cdadf29680
+cluster: dev-gcp
 envs:
   - name: TILTAKSPENGER_VEDTAK_URL
     value: http://tiltakspenger-vedtak
+  - name: TILTAKSPENGER_MELDEKORT_URL
+    value: http://tiltakspenger-meldekort-api
   - name: AUTH_PROVIDER_URL
     value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token
   - name: SCOPE

--- a/.nais/vars/prod.yaml
+++ b/.nais/vars/prod.yaml
@@ -4,9 +4,12 @@ replyURLs:
   - https://tiltakspenger-saksbehandler.intern.nav.no/oauth2/callback
 tenant: nav.no
 ROLE_SAKSBEHANDLER: 6c6ce2e8-b2e2-4c4b-8194-215c8e27a5c7
+cluster: prod-gcp
 envs:
   - name: TILTAKSPENGER_VEDTAK_URL
     value: http://tiltakspenger-vedtak
+  - name: TILTAKSPENGER_MELDEKORT_URL
+    value: http://tiltakspenger-meldekort-api
   - name: AUTH_PROVIDER_URL
     value: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/oauth2/v2.0/token
   - name: SCOPE

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
             }
         },
         "node_modules/@adobe/css-tools": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-            "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+            "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
             "dev": true
         },
         "node_modules/@ampproject/remapping": {
@@ -8963,9 +8963,9 @@
     },
     "dependencies": {
         "@adobe/css-tools": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-            "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+            "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
             "dev": true
         },
         "@ampproject/remapping": {

--- a/src/pages/api/[...middleware].ts
+++ b/src/pages/api/[...middleware].ts
@@ -3,11 +3,19 @@ import { getToken } from '../../utils/auth';
 import SimpleResponse from '../../types/SimpleResponse';
 import logger from '../../utils/serverLogger';
 
-const backendUrl = process.env.TILTAKSPENGER_VEDTAK_URL || '';
+const vedtakBackendUrl = process.env.TILTAKSPENGER_VEDTAK_URL || '';
+const meldekortBackendUrl = process.env.TILTAKSPENGER_MELDEKORT_URL || '';
 
 function getUrl(req: NextApiRequest): string {
-    const path = req?.url?.replace('/api', '');
-    return `${backendUrl}${path}`;
+    const urlTil = req?.url;
+
+    if (urlTil === '/meldekortapi') {
+        const meldekortPath = req?.url?.replace('/meldekortapi', '');
+        return `${meldekortBackendUrl}${meldekortPath}`;
+    } else {
+        const vedtakPath = req?.url?.replace('/api', '');
+        return `${vedtakBackendUrl}${vedtakPath}`;
+    }
 }
 
 async function makeApiRequest(request: NextApiRequest, oboToken: string): Promise<Response> {


### PR DESCRIPTION
## Beskrivelse
Sette opp inbound og outbound rules i TP-meldekort-api og TP-saksbehandler for å tilrettelegge for kommunikasjon.

## Kommentarer
Inbound rules var allerede lagt i TP-meldekort-api for å snakke med saksbehandler flaten så de er ikke lagt i denne PRen.

Endringer i env.local file som kan ikke merges:-
TILTAKSPENGER_MELDEKORT_URL=http://localhost:8081

## Visuelle endringer:
Tekniske endringer. Ingen visuelle endringer

