### PR TITLE
F Oppretter søkeresultat-side for saker, og saksoversikt-side for å se på en sak

### DIFF
--- a/src/hooks/useSokOppPerson.ts
+++ b/src/hooks/useSokOppPerson.ts
@@ -11,7 +11,7 @@ function useSokOppPerson(navigateToSoker: boolean = true) {
     '/api/soker',
     SøkerIdent
   >('/api/soker', fetchSøker, {
-    onSuccess: (data) => navigateToSoker && router.push(`/soker/${data.id}`),
+    onSuccess: (data) => navigateToSoker && router.push(`/saker/${data.id}`),
   });
 
   return { trigger, isSokerMutating };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,6 @@ import useSaksbehandler from '../hooks/useSaksbehandler';
 import { HovedLayout } from '../components/layout/HovedLayout';
 import { Loader } from '@navikt/ds-react';
 import { NextPage } from 'next';
-import { Behandling } from '../types/Behandling';
 
 interface SaksbehandlerContextType {
   innloggetSaksbehandler: Saksbehandler;

--- a/src/pages/sak/Sak.module.css
+++ b/src/pages/sak/Sak.module.css
@@ -1,0 +1,12 @@
+.saksside {
+    display: flex;
+    margin: 2rem;
+}
+
+.saksinfo {
+    display: block;
+}
+
+.revurderknapp {
+    margin-left: 2rem;
+}

--- a/src/pages/sak/[sakId].tsx
+++ b/src/pages/sak/[sakId].tsx
@@ -4,9 +4,10 @@ import {
   pageWithAuthentication,
   redirectToLogin,
 } from '../../utils/pageWithAuthentication';
-import { Button } from '@navikt/ds-react';
+import { Button, Heading } from '@navikt/ds-react';
 import { getOnBehalfOfToken } from '../../utils/auth';
 import { Sak } from '../../types/Behandling';
+import styles from './Sak.module.css';
 
 interface SakProps {
   saksnummer: string;
@@ -15,10 +16,14 @@ interface SakProps {
 
 const SakPage: NextPage<SakProps> = ({ saksnummer, ident }: SakProps) => {
   return (
-    <div>
-      <div> Saksnummer: {saksnummer}</div>
-      <div> Fødselsnummer: {ident}</div>
-      <Button>Revurder</Button>
+    <div className={styles.saksside}>
+      <div className={styles.saksinfo}>
+        <Heading size="medium">Saksnummer: {saksnummer}</Heading>
+        <Heading size="small">Fødselsnummer: {ident}</Heading>
+      </div>
+      <div>
+        <Button className={styles.revurderknapp}>Revurder</Button>
+      </div>
     </div>
   );
 };

--- a/src/pages/sak/[sakId].tsx
+++ b/src/pages/sak/[sakId].tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { NextPage } from 'next';
+import { pageWithAuthentication } from '../../utils/pageWithAuthentication';
+import { Button } from '@navikt/ds-react';
+
+interface SakProps {
+  saksnummer: string;
+  fødselsnummer: string;
+}
+
+const SakPage: NextPage<SakProps> = ({
+  saksnummer,
+  fødselsnummer,
+}: SakProps) => {
+  return (
+    <div>
+      <div> Saksnummer: {saksnummer}</div>
+      <div> Fødselsnummer: {fødselsnummer}</div>
+      <Button>Revurder</Button>
+    </div>
+  );
+};
+
+export default SakPage;
+
+export const getServerSideProps = pageWithAuthentication(async () => {
+  return {
+    props: {
+      saksnummer: 'foo',
+      fødselsnummer: 'bar',
+    },
+  };
+});

--- a/src/pages/saker/[søkerId].tsx
+++ b/src/pages/saker/[søkerId].tsx
@@ -6,18 +6,18 @@ import { SaksbehandlerContext } from '../_app';
 import { useRouter } from 'next/router';
 import useSWR, { useSWRConfig } from 'swr';
 import { fetcher } from '../../utils/http';
-import { Sak} from '../../types/Behandling';
+import { Sak } from '../../types/Behandling';
 
-const SøkerPage: NextPage = () => {
+const SakerPage: NextPage = () => {
   const router = useRouter();
   const søkerId = router.query.søkerId as string;
   const mutator = useSWRConfig().mutate;
   const { innloggetSaksbehandler } = useContext(SaksbehandlerContext);
 
   const { data, isLoading } = useSWR<Sak[]>(
-      `/api/sak/hentForIdent/${søkerId}`,
-      fetcher,
-      {}
+    `/api/sak/hentForSokerId/${søkerId}`,
+    fetcher,
+    {},
   );
 
   if (isLoading) {
@@ -28,79 +28,42 @@ const SøkerPage: NextPage = () => {
     fetch(`/api/behandling/startbehandling/${behandlingid}`, {
       method: 'POST',
     })
-        .then(() => {
-          mutator(`/api/behandlinger`);
-        })
-        .then(() => {
-          router.push(`/behandling/${behandlingid}`);
-        });
+      .then(() => {
+        mutator(`/api/behandlinger`);
+      })
+      .then(() => {
+        router.push(`/behandling/${behandlingid}`);
+      });
   };
 
-  const skalKunneTaBehandling = (
-      type: string,
-      saksbehandlerForBehandling?: string,
-      beslutterForBehandling?: string
-  ) => {
-    switch (type) {
-      case 'Klar til beslutning':
-        return (
-            innloggetSaksbehandler?.roller.includes('BESLUTTER') &&
-            !beslutterForBehandling &&
-            innloggetSaksbehandler?.navIdent != saksbehandlerForBehandling
-        );
-      case 'Klar til behandling':
-        return (
-            innloggetSaksbehandler?.roller.includes('SAKSBEHANDLER') &&
-            !saksbehandlerForBehandling
-        );
-      default:
-        return false;
-    }
-  };
+  const sakerForIdent = data;
 
-  let sakerForIdent = data;
-
-  sakerForIdent = [
-    {
-      id: '1234',
-      ident:'5678'
-    }
-  ]
-
-  const behandlingLinkAktivert = (
-      saksbehandlerForBehandling?: string,
-      beslutterForBehandling?: string
-  ) => {
-    return (
-        innloggetSaksbehandler?.navIdent == saksbehandlerForBehandling ||
-        innloggetSaksbehandler?.navIdent == beslutterForBehandling ||
-        innloggetSaksbehandler?.roller.includes('ADMINISTRATOR')
-    );
-  };
   return (
-      <div style={{ paddingLeft: '1rem' }}>
-        <Table zebraStripes>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell scope="col">Saksnummer</Table.HeaderCell>
-              <Table.HeaderCell scope="col"></Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {sakerForIdent?.map((sak) => {
-              return (
-                  <Table.Row shadeOnHover={false} key={sak.id}>
-                    <Table.DataCell>{sak.id}</Table.DataCell>
-                    <Table.DataCell>Se sak</Table.DataCell>
-                  </Table.Row>
-              );
-            })}
-          </Table.Body>
-        </Table>
-      </div>
+    <div style={{ paddingLeft: '1rem' }}>
+      <Table zebraStripes>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell scope="col">Saksnummer</Table.HeaderCell>
+            <Table.HeaderCell scope="col"></Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {sakerForIdent?.map((sak) => {
+            return (
+              <Table.Row shadeOnHover={false} key={sak.id}>
+                <Table.DataCell>{sak.id}</Table.DataCell>
+                <Table.DataCell>
+                  <Link href={`/sak/${sak.id}`}>Se sak</Link>
+                </Table.DataCell>
+              </Table.Row>
+            );
+          })}
+        </Table.Body>
+      </Table>
+    </div>
   );
 };
 
-export default SøkerPage;
+export default SakerPage;
 
 export const getServerSideProps = pageWithAuthentication();

--- a/src/pages/saker/[søkerId].tsx
+++ b/src/pages/saker/[søkerId].tsx
@@ -44,16 +44,18 @@ const SakerPage: NextPage = () => {
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell scope="col">Saksnummer</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Fødselsnummer</Table.HeaderCell>
             <Table.HeaderCell scope="col"></Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
           {sakerForIdent?.map((sak) => {
             return (
-              <Table.Row shadeOnHover={false} key={sak.id}>
-                <Table.DataCell>{sak.id}</Table.DataCell>
+              <Table.Row shadeOnHover={false} key={sak.saksnummer}>
+                <Table.DataCell>{sak.saksnummer}</Table.DataCell>
+                <Table.DataCell>{sak.ident}</Table.DataCell>
                 <Table.DataCell>
-                  <Link href={`/sak/${sak.id}`}>Se sak</Link>
+                  <Link href={`/sak/${sak.saksnummer}`}>Se sak</Link>
                 </Table.DataCell>
               </Table.Row>
             );

--- a/src/pages/saker/[søkerId].tsx
+++ b/src/pages/saker/[søkerId].tsx
@@ -1,18 +1,15 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { NextPage } from 'next';
 import { pageWithAuthentication } from '../../utils/pageWithAuthentication';
-import { Button, Link, Loader, Table } from '@navikt/ds-react';
-import { SaksbehandlerContext } from '../_app';
+import { Link, Loader, Table } from '@navikt/ds-react';
 import { useRouter } from 'next/router';
-import useSWR, { useSWRConfig } from 'swr';
+import useSWR from 'swr';
 import { fetcher } from '../../utils/http';
 import { Sak } from '../../types/Behandling';
 
 const SakerPage: NextPage = () => {
   const router = useRouter();
   const søkerId = router.query.søkerId as string;
-  const mutator = useSWRConfig().mutate;
-  const { innloggetSaksbehandler } = useContext(SaksbehandlerContext);
 
   const { data, isLoading } = useSWR<Sak[]>(
     `/api/sak/hentForSokerId/${søkerId}`,
@@ -23,18 +20,6 @@ const SakerPage: NextPage = () => {
   if (isLoading) {
     return <Loader />;
   }
-
-  const taBehandling = async (behandlingid: string) => {
-    fetch(`/api/behandling/startbehandling/${behandlingid}`, {
-      method: 'POST',
-    })
-      .then(() => {
-        mutator(`/api/behandlinger`);
-      })
-      .then(() => {
-        router.push(`/behandling/${behandlingid}`);
-      });
-  };
 
   const sakerForIdent = data;
 

--- a/src/pages/saker/[søkerId].tsx
+++ b/src/pages/saker/[søkerId].tsx
@@ -1,0 +1,106 @@
+import React, { useContext } from 'react';
+import { NextPage } from 'next';
+import { pageWithAuthentication } from '../../utils/pageWithAuthentication';
+import { Button, Link, Loader, Table } from '@navikt/ds-react';
+import { SaksbehandlerContext } from '../_app';
+import { useRouter } from 'next/router';
+import useSWR, { useSWRConfig } from 'swr';
+import { fetcher } from '../../utils/http';
+import { Sak} from '../../types/Behandling';
+
+const SøkerPage: NextPage = () => {
+  const router = useRouter();
+  const søkerId = router.query.søkerId as string;
+  const mutator = useSWRConfig().mutate;
+  const { innloggetSaksbehandler } = useContext(SaksbehandlerContext);
+
+  const { data, isLoading } = useSWR<Sak[]>(
+      `/api/sak/hentForIdent/${søkerId}`,
+      fetcher,
+      {}
+  );
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  const taBehandling = async (behandlingid: string) => {
+    fetch(`/api/behandling/startbehandling/${behandlingid}`, {
+      method: 'POST',
+    })
+        .then(() => {
+          mutator(`/api/behandlinger`);
+        })
+        .then(() => {
+          router.push(`/behandling/${behandlingid}`);
+        });
+  };
+
+  const skalKunneTaBehandling = (
+      type: string,
+      saksbehandlerForBehandling?: string,
+      beslutterForBehandling?: string
+  ) => {
+    switch (type) {
+      case 'Klar til beslutning':
+        return (
+            innloggetSaksbehandler?.roller.includes('BESLUTTER') &&
+            !beslutterForBehandling &&
+            innloggetSaksbehandler?.navIdent != saksbehandlerForBehandling
+        );
+      case 'Klar til behandling':
+        return (
+            innloggetSaksbehandler?.roller.includes('SAKSBEHANDLER') &&
+            !saksbehandlerForBehandling
+        );
+      default:
+        return false;
+    }
+  };
+
+  let sakerForIdent = data;
+
+  sakerForIdent = [
+    {
+      id: '1234',
+      ident:'5678'
+    }
+  ]
+
+  const behandlingLinkAktivert = (
+      saksbehandlerForBehandling?: string,
+      beslutterForBehandling?: string
+  ) => {
+    return (
+        innloggetSaksbehandler?.navIdent == saksbehandlerForBehandling ||
+        innloggetSaksbehandler?.navIdent == beslutterForBehandling ||
+        innloggetSaksbehandler?.roller.includes('ADMINISTRATOR')
+    );
+  };
+  return (
+      <div style={{ paddingLeft: '1rem' }}>
+        <Table zebraStripes>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell scope="col">Saksnummer</Table.HeaderCell>
+              <Table.HeaderCell scope="col"></Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {sakerForIdent?.map((sak) => {
+              return (
+                  <Table.Row shadeOnHover={false} key={sak.id}>
+                    <Table.DataCell>{sak.id}</Table.DataCell>
+                    <Table.DataCell>Se sak</Table.DataCell>
+                  </Table.Row>
+              );
+            })}
+          </Table.Body>
+        </Table>
+      </div>
+  );
+};
+
+export default SøkerPage;
+
+export const getServerSideProps = pageWithAuthentication();

--- a/src/types/Behandling.ts
+++ b/src/types/Behandling.ts
@@ -49,6 +49,11 @@ export interface BehandlingForBenk {
   beslutter?: string;
 }
 
+export interface Sak {
+  id: string;
+  ident: string;
+}
+
 export interface Personopplysninger {
   ident: string;
   fornavn: string;

--- a/src/types/Behandling.ts
+++ b/src/types/Behandling.ts
@@ -50,7 +50,7 @@ export interface BehandlingForBenk {
 }
 
 export interface Sak {
-  id: string;
+  saksnummer: string;
   ident: string;
 }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -36,7 +36,7 @@ async function makeOnBehalfOfGrant(body: URLSearchParams) {
   });
 }
 
-async function getOnBehalfOfToken(
+export async function getOnBehalfOfToken(
   token: string,
   scope: string
 ): Promise<SimpleResponse | string> {


### PR DESCRIPTION
## Beskrivelse
Oppretter søkeresultat-side for saker, og saksoversikt-side for å se på en sak

## Kommentarer
* På saksoversikt-siden henter vi data om Sak ved hjelp av getServerSideProps, eksempel på hvordan man gjør tokenveksling etc. ligger i `[saksnummer].tsx`.

## Visuelle endringer:
https://www.figma.com/proto/YIBampWurMFpyhqvQZIxjH/Tiltakspenger---konseptutvikling?page-id=1%3A2&type=design&node-id=95-4193&viewport=1722%2C-2843%2C0.36&t=P79PXnsIjhY16D1V-1&scaling=min-zoom&starting-point-node-id=95%3A4188
