### PR TITLE
F - Legg på modal for bekreftelse før meldekortet godkjennes av beslutter

### DIFF
--- a/src/components/bekreftelsesmodal/BekreftelsesModal.module.css
+++ b/src/components/bekreftelsesmodal/BekreftelsesModal.module.css
@@ -1,0 +1,3 @@
+.modal {
+  padding: 2rem;
+}

--- a/src/components/bekreftelsesmodal/BekreftelsesModal.tsx
+++ b/src/components/bekreftelsesmodal/BekreftelsesModal.tsx
@@ -1,0 +1,52 @@
+import { Alert, BodyShort, Button, Modal } from '@navikt/ds-react';
+import { ReactNode, RefObject } from 'react';
+import styles from './BekreftelsesModal.module.css';
+import { FetcherError } from '../../utils/http';
+
+interface BekreftelsesModalProps {
+  modalRef: RefObject<HTMLDialogElement>;
+  children?: ReactNode;
+  tittel: string;
+  body: string;
+  error?: FetcherError;
+  lukkModal: () => void;
+}
+
+const BekreftelseseModal = ({
+  modalRef,
+  children,
+  tittel,
+  body,
+  error,
+  lukkModal,
+}: BekreftelsesModalProps) => {
+  return (
+    <Modal
+      ref={modalRef}
+      width="medium"
+      className={styles.modal}
+      aria-label="Legg til bekreftelses"
+      onClose={() => {
+        lukkModal();
+      }}
+      header={{ heading: tittel }}
+    >
+      <Modal.Body>
+        <BodyShort>{body}</BodyShort>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button type="button" variant="secondary" onClick={() => lukkModal()}>
+          Nei, avbryt
+        </Button>
+        {children}
+      </Modal.Footer>
+      {error && (
+        <Alert variant="error" style={{ margin: '1rem' }}>
+          {error.message}
+        </Alert>
+      )}
+    </Modal>
+  );
+};
+
+export default BekreftelseseModal;

--- a/src/components/meldekort/meldekortside/MeldekortKnapper.tsx
+++ b/src/components/meldekort/meldekortside/MeldekortKnapper.tsx
@@ -4,6 +4,8 @@ import { MeldekortDag, Meldekortstatus } from '../../../types/MeldekortTypes';
 import { useSendMeldekortTilBeslutter } from '../../../hooks/meldekort/useSendMeldekortTilBeslutter';
 import { useHentMeldekort } from '../../../hooks/meldekort/useHentMeldekort';
 import { useGodkjennMeldekort } from '../../../hooks/meldekort/useGodkjennMeldekort';
+import BekreftelseseModal from '../../bekreftelsesmodal/BekreftelsesModal';
+import { useRef } from 'react';
 
 interface MeldekortKnapperProps {
   meldekortdager: MeldekortDag[];
@@ -19,10 +21,19 @@ export const MeldekortKnapper = ({
   const { sendMeldekortTilBeslutter, senderMeldekortTilBeslutter, error } =
     useSendMeldekortTilBeslutter(meldekortId, sakId);
   const { meldekort } = useHentMeldekort(meldekortId, sakId);
-  const { onGodkjennMeldekort, isMeldekortMutating } = useGodkjennMeldekort(
-    meldekortId,
-    sakId,
-  );
+  const {
+    onGodkjennMeldekort,
+    isMeldekortMutating,
+    feilVedGodkjenning,
+    reset,
+  } = useGodkjennMeldekort(meldekortId, sakId);
+  const modalRef = useRef(null);
+
+  const lukkModal = () => {
+    modalRef.current.close();
+    reset();
+  };
+
   return (
     <HStack gap="3">
       {error && (
@@ -50,13 +61,32 @@ export const MeldekortKnapper = ({
         <Button
           size="small"
           loading={isMeldekortMutating}
-          onClick={() => onGodkjennMeldekort()}
+          onClick={() => modalRef.current?.showModal()}
         >
           Godkjenn meldekort
         </Button>
       ) : (
         <></>
       )}
+      <BekreftelseseModal
+        modalRef={modalRef}
+        tittel={'Godkjenn meldekortet'}
+        body={
+          'Er du sikker på at meldekortet er korrekt og ønsker å sende det til utbetaling?'
+        }
+        error={feilVedGodkjenning}
+        lukkModal={lukkModal}
+      >
+        <Button
+          variant="primary"
+          loading={isMeldekortMutating}
+          onClick={() => {
+            onGodkjennMeldekort();
+          }}
+        >
+          Godkjenn meldekort
+        </Button>
+      </BekreftelseseModal>
     </HStack>
   );
 };

--- a/src/hooks/meldekort/useGodkjennMeldekort.ts
+++ b/src/hooks/meldekort/useGodkjennMeldekort.ts
@@ -18,12 +18,13 @@ export function useGodkjennMeldekort(meldekortId: string, sakId: string) {
   const {
     trigger: onGodkjennMeldekort,
     isMutating: isMeldekortMutating,
-    error,
+    error: feilVedGodkjenning,
+    reset
   } = useSWRMutation<any, FetcherError, any, any>(
     `/api/sak/${sakId}/meldekort/${meldekortId}/iverksett`,
     mutateMeldekort,
     { onSuccess: () => mutate(`/api/sak/${sakId}/meldekort/${meldekortId}`) },
   );
 
-  return { onGodkjennMeldekort, isMeldekortMutating, error };
+  return { onGodkjennMeldekort, isMeldekortMutating, feilVedGodkjenning , reset};
 }


### PR DESCRIPTION



## Beskrivelse
Laget en BekreftelsesModal som kan gjenbrukes videre på steder hvor saksbehandler eller beslutter må få opp et ekstra lag med godkjenning. Lagt på nå når beslutter sender til meldekortet til godkjenning


## Visuelle endringer:
![image](https://github.com/user-attachments/assets/9bfafe25-1927-41f4-b2ac-4c84526bf08d)
